### PR TITLE
Updated Firebase database reference; fixed bug

### DIFF
--- a/Orlando Walking Tours/Services/FirebaseDataService.swift
+++ b/Orlando Walking Tours/Services/FirebaseDataService.swift
@@ -24,7 +24,7 @@ struct FirebaseDataService : DataService
 
     func getLocations(completion: (locations: [HistoricLocation]) -> Void)
     {
-        let historicLocationsRef = databaseRef.child("historic-locations")
+        let historicLocationsRef = databaseRef.child("historic-locations").child("orlando")
 
         historicLocationsRef.observeSingleEventOfType(.Value, withBlock:
         { snapshot in

--- a/Orlando Walking Tours/Storyboards/Dashboard.storyboard
+++ b/Orlando Walking Tours/Storyboards/Dashboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1PF-Sg-EgP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1PF-Sg-EgP">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -36,7 +36,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DashboardCell" id="2ha-fR-Q1R" customClass="DashboardCollectionViewCell" customModule="Orlando_Walking_Tours" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DashboardCollectionViewCell" id="2ha-fR-Q1R" customClass="DashboardCollectionViewCell" customModule="Orlando_Walking_Tours" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="150" height="150"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -98,7 +98,7 @@
                                             <outlet property="tourName" destination="Vvi-bI-HAX" id="tYr-Cf-7Ln"/>
                                         </connections>
                                     </collectionViewCell>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AddTourCell" id="lM1-S8-F5l" customClass="AddTourCollectionViewCell" customModule="Orlando_Walking_Tours" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="AddTourCollectionViewCell" id="lM1-S8-F5l" customClass="AddTourCollectionViewCell" customModule="Orlando_Walking_Tours" customModuleProvider="target">
                                         <rect key="frame" x="225" y="0.0" width="150" height="150"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">


### PR DESCRIPTION
I am making changes to the Firebase database that holds the historic locations, so I needed to update the FirebaseDataService to reflect those changes.  Also, I discovered that there was a bug after my last pull request.  The app was crashing when the Dashboard was about to be displayed after having created a new Tour.  This was because I changed the reuse identifiers for the collection view cells in code but did not make the appropriate change in the Dashboard.storyboard.
