### PR TITLE
Fixed dashboard crash (fixes #88)

### DIFF
--- a/Orlando Walking Tours/Controllers/DashboardVC.swift
+++ b/Orlando Walking Tours/Controllers/DashboardVC.swift
@@ -125,7 +125,7 @@ class DashboardVC: UIViewController, UICollectionViewDataSource, UICollectionVie
                     self.modelService.deleteTour(tour: self.tours[indexPath.item])
                     { (success, error) in
                         self.tours.removeAtIndex(indexPath.item)
-                        self.collectionView.deleteItemsAtIndexPaths([indexPath])
+                        self.collectionView.reloadData()
                     }
                 }
             }
@@ -143,6 +143,11 @@ class DashboardVC: UIViewController, UICollectionViewDataSource, UICollectionVie
 
     func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int
     {
+        if (self.tours.count == 0) && (self.newTourView.hidden)
+        {
+            self.newTourView.hidden = false
+        }
+
         return (self.tours.count > 0) ? self.tours.count + 1 : self.tours.count
     }
 


### PR DESCRIPTION
Dashboard was crashing when I deleted the last tour on the dashboard because of how I was adding a new "Add Tour" collection view.  Instead of manually removing the cell from the collection view, I am simply calling reloadData() now, which takes care of that crash.

On top of the crash, when implementing the above change, the "AddTourView" that is normally shown when there are no tours on the Dashboard wasn't being shown after that last tour was deleted.  I added code to numberOfItemsInSection() that will show the view when the number of tours is zero and the tour is currently hidden.
