### PR TITLE
update rowHeight constraint issue

### DIFF
--- a/Orlando Walking Tours/Controllers/CurrentTourVC.swift
+++ b/Orlando Walking Tours/Controllers/CurrentTourVC.swift
@@ -137,6 +137,7 @@ extension CurrentTourVC: UITableViewDelegate, UITableViewDataSource
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat
     {
+        tableView.rowHeight = UITableViewAutomaticDimension
         return 70
     }
 


### PR DESCRIPTION
I noticed the tableview height was collapsing on itself and have a proposed change to allow for automatic height constraints based on the content inside and a `estimatedRowHeight` of 70